### PR TITLE
Fix dtype conversion for synthesized audio

### DIFF
--- a/api/server.py
+++ b/api/server.py
@@ -326,9 +326,12 @@ class VibeVoiceTTS:
 
         audio = speech_outputs[0]
         if isinstance(audio, torch.Tensor):
-            waveform = audio.detach().cpu().numpy()
+            waveform_tensor = audio.detach()
+            if waveform_tensor.dtype != torch.float32:
+                waveform_tensor = waveform_tensor.to(torch.float32)
+            waveform = waveform_tensor.cpu().numpy()
         else:
-            waveform = np.asarray(audio)
+            waveform = np.asarray(audio, dtype=np.float32)
 
         if waveform.ndim > 1:
             waveform = waveform.squeeze()


### PR DESCRIPTION
## Summary
- ensure synthesized audio tensors are converted to float32 before moving to NumPy to avoid unsupported dtype errors
- default non-tensor audio outputs to float32 arrays for consistent downstream handling

## Testing
- python -m compileall api/server.py

------
https://chatgpt.com/codex/tasks/task_e_68d06bed3860832bbaab82d75678e75e