### PR TITLE
Enable streaming responses and save synthesized audio

### DIFF
--- a/api/README.md
+++ b/api/README.md
@@ -57,6 +57,7 @@ uvicorn api.server:app --host 0.0.0.0 --port 8000
 | CFG scale | `--cfg_scale` | `VIBEVOICE_CFG_SCALE` | `1.3` |
 | Diffusion inference steps | `--inference_steps` | `VIBEVOICE_INFERENCE_STEPS` | `5` |
 | Voices directory | `--voices_dir` | `VIBEVOICE_VOICES_DIR` | `api/voices` |
+| Output directory for saved MP3 files | `--output_dir` | `VIBEVOICE_OUTPUT_DIR` | `api/output` |
 
 ## API Usage
 
@@ -68,10 +69,13 @@ Send a POST request to `/v1/audio/speech` with a JSON body mirroring the OpenAI 
   "input": "Hello from VibeVoice!",
   "voice": "en-Alice_woman",
   "response_format": "mp3",
-  "cfg_scale": 1.3
+  "cfg_scale": 1.3,
+  "stream": true
 }
 ```
 
-The response streams the synthesized audio using the requested format. Supported `response_format` values are `mp3`, `wav`, and `flac`.
+Responses stream audio by default so playback can begin as soon as data is available. Set `"stream": false` to receive the complete file in a single response.
+
+Supported `response_format` values are `mp3`, `wav`, and `flac`. Regardless of the requested format, an MP3 copy of the generated audio is saved to the configured output directory (default `api/output`).
 
 Errors are returned in JSON with appropriate HTTP status codes if the input is invalid, a voice preset is missing, or speech synthesis fails.


### PR DESCRIPTION
## Summary
- stream synthesized audio by default using an async FFmpeg pipeline and save a copy as MP3
- add an output directory configuration option and persist generated audio files there
- document the new streaming flag and output-directory settings in the API README

## Testing
- python -m compileall api/server.py

------
https://chatgpt.com/codex/tasks/task_e_68d06fe90df4832bbe4ce85b93ea9703